### PR TITLE
Add way to configure custom NLTK data path

### DIFF
--- a/config/ores.yaml
+++ b/config/ores.yaml
@@ -83,3 +83,7 @@ languages:
     module: revscoring.languages.persian
   french:
     module: revscoring.languages.french
+
+# Data path
+data_path:
+  nltk: /srv/ores/data/nltk

--- a/ores/wsgi/application.py
+++ b/ores/wsgi/application.py
@@ -1,13 +1,17 @@
 import json
 import os
 
-from flask import Blueprint, Flask, request
-from revscoring.scorers import Scorer
-
-from . import routes
-
 
 def configure(config):
+    if 'data_path' in config and 'nltk' in config['data_path']:
+        import nltk
+        nltk.data.path.append(config['data_path']['nltk'])
+
+    from flask import Blueprint, Flask, request
+    from revscoring.scorers import Scorer
+
+    from . import routes
+
     app = Flask("ores")
     app.config["APPLICATION_ROOT"] = config['application_root']
 


### PR DESCRIPTION
This allows us to manage where to download the data, which
is important when using a virtualenv for automated deploys