### PR TITLE
Install HEAD of revscoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-revscoring
+git+git://github.com/halfak/Revision-Scoring.git#egg=revscoring
 mediawiki-utilities
 flask
 flask-jsonpify


### PR DESCRIPTION
So that updates to revscoring are actually pulled in without
having to wait for a new version to be uploaded to pypi.
We can switch it back once everything's stabilized, I think.